### PR TITLE
Update config for Render monolith deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx api/index.ts",
     "build": "vite build",
-    "prestart": "npm run build",
     "start": "NODE_ENV=production tsx api/index.ts",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx api/index.ts",
     "build": "vite build",
+    "prestart": "npm run build",
     "start": "NODE_ENV=production tsx api/index.ts",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
-  
-  root: 'client', 
+
+  root: 'client',
+
+  base: '/',
   
   build: {
     outDir: '../api/public',


### PR DESCRIPTION
## Summary
- adjust Vite build so static files output to `api/public` with base `/`
- automatically build client before starting server

## Testing
- `npm run start`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b969659c88324a5c7ee89bdba66f6