### PR TITLE
Fix missing schema import in transaction form

### DIFF
--- a/client/src/components/transactions/transaction-form.tsx
+++ b/client/src/components/transactions/transaction-form.tsx
@@ -43,7 +43,7 @@ import { format } from "date-fns";
 import { es } from "date-fns/locale";
 
 // Extend the transaction schema for form validation
-const formSchema = insertTransactionSchema.extend({
+const formSchema = formTransactionSchema.extend({
   date: z.date({
     required_error: "La fecha es requerida",
   }),


### PR DESCRIPTION
## Summary
- correct the schema reference in `TransactionForm`

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ca22e62c08324a12697937427841c